### PR TITLE
Tracker Trait

### DIFF
--- a/src/WithHistoryTracker.php
+++ b/src/WithHistoryTracker.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Imanghafoori\EloquentHistory;
+
+trait WithHistoryTracker
+{
+    protected static function bootWithHistoryTracker()
+    {
+        HistoryTracker::track(static::class, static::$historyTrackerExceptions ?? []);
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -159,9 +159,9 @@ class IntegrationTest extends TestCase
         HistoryTracker::track(User::class, $exceptions);
     }
 
-    private function createNewUser($factory = null)
+    private function createNewUser()
     {
-        return factory($factory ?? User::class)->create();
+        return factory(User::class)->create();
     }
 
     private function untrackAllModels(): void


### PR DESCRIPTION
Adding `WithHistoryTracker` trait in order to have a more convenient and flexible way for tracking histories.

There are situations where we don't want to populate our service providers by registering trackers, Or we don't want to make a new provider just for registering trackers, It would be useful to just `use` this trait in our desired model(s) in order to track their histories.

As an example:
```php
use Imanghafoori\EloquentHistory\WithHistoryTracker;

class User extends Authenticatable
{
    use WithHistoryTracker;
    ...
}

``` 

It also supports the `column exception` feature of tracker:
```php
use Imanghafoori\EloquentHistory\WithHistoryTracker;

class User extends Authenticatable
{
    use WithHistoryTracker;

    private static $historyTrackerExceptions = ['name', 'age']; 
    ...
}

``` 
